### PR TITLE
Add direct link to logs from chat card

### DIFF
--- a/app/views/chats/_chat_card.html.erb
+++ b/app/views/chats/_chat_card.html.erb
@@ -1,6 +1,7 @@
 <div class="card bg-base-200 shadow-xl h-full place-content-between">
     <div class="card-body">
         <div class="card-title divider text-lg sm:text-sm underline"><%= link_to chat.url, chat %></div>
+        <div class="logs-link justify-centre text-sm"><%= "Logs", log_chat_path(chat), target: "_blank" %></div>
         <% if chat.group_chat? %>
             <div class="collapse collapse-arrow bg-base-300 max-w-full">
                 <input type="checkbox" name="chat-accordion" /> 
@@ -22,9 +23,6 @@
             <% if current_account && current_account.chats.include?(chat) %>
                 <p>Visited</p>
             <% end %>
-            <div class="logs-link justify-centre">
-                <p>Logs</p><%= link_to chat.url+"/log", chat %>
-            </div>
             <div class="badge badge-outline">
                 <%= chat.type %>
             </div>

--- a/app/views/chats/_chat_card.html.erb
+++ b/app/views/chats/_chat_card.html.erb
@@ -1,7 +1,7 @@
 <div class="card bg-base-200 shadow-xl h-full place-content-between">
     <div class="card-body">
         <div class="card-title divider text-lg sm:text-sm underline"><%= link_to chat.url, chat %></div>
-        <div class="logs-link justify-centre text-sm underline"><%= "Logs", log_chat_path(chat), target: "_blank" %></div>
+        <%= link_to "Logs", log_chat_path(chat), target: "_blank", class: "justify-self-center underline text-center" %>
         <% if chat.group_chat? %>
             <div class="collapse collapse-arrow bg-base-300 max-w-full">
                 <input type="checkbox" name="chat-accordion" /> 

--- a/app/views/chats/_chat_card.html.erb
+++ b/app/views/chats/_chat_card.html.erb
@@ -22,6 +22,9 @@
             <% if current_account && current_account.chats.include?(chat) %>
                 <p>Visited</p>
             <% end %>
+            <div class="logs-link justify-centre">
+                <p>Logs</p><%= link_to chat.url+"/log", chat %>
+            </div>
             <div class="badge badge-outline">
                 <%= chat.type %>
             </div>

--- a/app/views/chats/_chat_card.html.erb
+++ b/app/views/chats/_chat_card.html.erb
@@ -1,7 +1,7 @@
 <div class="card bg-base-200 shadow-xl h-full place-content-between">
     <div class="card-body">
         <div class="card-title divider text-lg sm:text-sm underline"><%= link_to chat.url, chat %></div>
-        <div class="logs-link justify-centre text-sm"><%= "Logs", log_chat_path(chat), target: "_blank" %></div>
+        <div class="logs-link justify-centre text-sm underline"><%= "Logs", log_chat_path(chat), target: "_blank" %></div>
         <% if chat.group_chat? %>
             <div class="collapse collapse-arrow bg-base-300 max-w-full">
                 <input type="checkbox" name="chat-accordion" /> 


### PR DESCRIPTION
I still want to view logs of my chats without having to join the chat + scroll up to the top. 

(i will admit, the ruby link_to with "/log" is untested as i did this in the browser editor)

example screenshot:
![image](https://github.com/hecksadecimal/newerparp/assets/39305711/7bf49984-21d0-41f1-aa03-5d988cfd01cf)
